### PR TITLE
UNT-T24349: Fix deep link crash

### DIFF
--- a/app/src/main/java/com/simform/ssfurnicraftar/data/local/LocalDataSource.kt
+++ b/app/src/main/java/com/simform/ssfurnicraftar/data/local/LocalDataSource.kt
@@ -10,7 +10,7 @@ class LocalDataSource @Inject constructor(
     private val categoryAndProductDao: CategoryAndProductDao
 ) {
 
-    fun getCategories(): List<Category> = Category.entries
+    fun getCategories(): List<Category> = Category.entries.dropWhile { it == Category.UNKNOWN }
 
     suspend fun getProductCategory(productId: String) = withContext(Dispatchers.IO) {
         categoryAndProductDao.getCategoryByProductId(productId)

--- a/app/src/main/java/com/simform/ssfurnicraftar/data/local/database/dao/CategoryAndProductDao.kt
+++ b/app/src/main/java/com/simform/ssfurnicraftar/data/local/database/dao/CategoryAndProductDao.kt
@@ -71,7 +71,7 @@ abstract class CategoryAndProductDao : ProductDao, CategoryDao {
             WHERE productId = :productId
         """
     )
-    abstract suspend fun getCategoryByProductId(productId: String): CategoryEntity
+    abstract suspend fun getCategoryByProductId(productId: String): CategoryEntity?
 
     /**
      * Delete all categories and products

--- a/app/src/main/java/com/simform/ssfurnicraftar/data/model/Category.kt
+++ b/app/src/main/java/com/simform/ssfurnicraftar/data/model/Category.kt
@@ -7,12 +7,15 @@ enum class Category(
     val slug: String,
     @StringRes val nameRes: Int
 ) {
+    UNKNOWN("unknown", R.string.category_unknown),
     TABLE("table", R.string.category_table),
     CHAIR("chair", R.string.category_chair),
     BED("bed", R.string.category_bed),
     SOFA("sofa", R.string.category_sofa),
     DESK("desk", R.string.category_desk),
     AC("ac", R.string.category_ac);
+
+
 
     companion object {
         fun valueOrNull(slug: String): Category? = entries.find { it.slug == slug }

--- a/app/src/main/java/com/simform/ssfurnicraftar/data/remote/NetworkDataSource.kt
+++ b/app/src/main/java/com/simform/ssfurnicraftar/data/remote/NetworkDataSource.kt
@@ -5,6 +5,7 @@ import com.simform.ssfurnicraftar.data.remote.api.DownloadService
 import com.simform.ssfurnicraftar.data.remote.apiresult.ApiResult
 import com.simform.ssfurnicraftar.data.remote.model.DownloadStatus
 import com.simform.ssfurnicraftar.data.remote.model.NetworkDownload
+import com.simform.ssfurnicraftar.data.remote.model.NetworkModel
 import com.simform.ssfurnicraftar.data.remote.model.NetworkModels
 import kotlinx.coroutines.flow.Flow
 import java.nio.file.Path
@@ -17,6 +18,9 @@ class NetworkDataSource @Inject constructor(
 
     suspend fun getModels(tag: String, cursor: String): ApiResult<NetworkModels> =
         apiService.getModels(tag, cursor)
+
+    suspend fun getModelInfo(modelId: String): ApiResult<NetworkModel> =
+        apiService.getModelInfo(modelId)
 
     suspend fun getDownloadInfo(modelId: String): ApiResult<NetworkDownload> =
         apiService.getDownloadInfo(modelId)

--- a/app/src/main/java/com/simform/ssfurnicraftar/data/remote/api/ApiService.kt
+++ b/app/src/main/java/com/simform/ssfurnicraftar/data/remote/api/ApiService.kt
@@ -2,6 +2,7 @@ package com.simform.ssfurnicraftar.data.remote.api
 
 import com.simform.ssfurnicraftar.data.remote.apiresult.ApiResult
 import com.simform.ssfurnicraftar.data.remote.model.NetworkDownload
+import com.simform.ssfurnicraftar.data.remote.model.NetworkModel
 import com.simform.ssfurnicraftar.data.remote.model.NetworkModels
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -17,6 +18,9 @@ interface ApiService {
         @Query("tags") category: String = "table",
         @Query("cursor") cursor: String? = null
     ): ApiResult<NetworkModels>
+
+    @GET("models/{modelId}")
+    suspend fun getModelInfo(@Path("modelId") id: String): ApiResult<NetworkModel>
 
     @GET("models/{modelId}/download")
     suspend fun getDownloadInfo(@Path("modelId") id: String): ApiResult<NetworkDownload>

--- a/app/src/main/java/com/simform/ssfurnicraftar/domain/GetPlaneTypeByCategoryUseCase.kt
+++ b/app/src/main/java/com/simform/ssfurnicraftar/domain/GetPlaneTypeByCategoryUseCase.kt
@@ -11,6 +11,7 @@ private val verticalCategories = setOf(Category.AC)
 class GetPlaneTypeByCategoryUseCase @Inject constructor() {
 
     operator fun invoke(category: Category): PlaneType = when {
+        category == Category.UNKNOWN -> PlaneType.HORIZONTAL_AND_VERTICAL
         verticalCategories.contains(category) -> PlaneType.VERTICAL
         else -> PlaneType.HORIZONTAL
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
 
     <!-- Products Screen -->
     <string name="no_data">No Data</string>
+    <string name="category_unknown">Unknown</string>
     <string name="category_table">Table</string>
     <string name="category_chair">Chair</string>
     <string name="category_bed">Bed</string>


### PR DESCRIPTION
Fix crash when app is open using deep link and model is not present in room db.
With these changes if the product info is not already present in the database, then fetch it from the remote source (i.e. API)